### PR TITLE
Update Get-WHFBCA.ps1

### DIFF
--- a/WHFBCHECKS/private/Get-WHFBCA.ps1
+++ b/WHFBCHECKS/private/Get-WHFBCA.ps1
@@ -11,7 +11,7 @@ function get-WHFBCA {
     if ($ca.Children.cn.count -gt 1) {
         $res = [System.Collections.ArrayList]::new()
         foreach ($c in $ca) {
-            $CASvr = get-adcomputer $c.cn -properties *
+            $CASvr = get-adcomputer $c.cn.ToString() -properties *
             $caa = [PSCustomObject]@{
                 Name    = $c.cn
                 CAName  = $c.children.cn[0]


### PR DESCRIPTION
Get-ADComputer throws an error when there is more than 1 CA listed. 

Get-ADComputer : Cannot convert 'System.DirectoryServices.PropertyValueCollection' to the type 'Microsoft.ActiveDirectory.Management.ADComputer' 
required by parameter 'Identity'. Specified method is not supported.
At C:\Users\Administrator.CPDESK\Downloads\WHfBChecks-main\WHfBChecks-main\WHFBCHECKS\Private\Get-WHFBCA.ps1:14 char:37
+             $CASvr = get-adcomputer $c.cn -properties *
+                                     ~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Get-ADComputer], ParameterBindingException
    + FullyQualifiedErrorId : CannotConvertArgument,Microsoft.ActiveDirectory.Management.Commands.GetADComputer