### PR TITLE
Enable Parser for CDP

### DIFF
--- a/WHFBCHECKS/public/test-WHFB.ps1
+++ b/WHFBCHECKS/public/test-WHFB.ps1
@@ -253,9 +253,9 @@ function Test-WHFB {
             else {
                 foreach ($CertCRLDP in $CertCRLDPs) {
                     $CRLServername = $CertCRLDP.Split('/')[2]
-                    #if ( ($CertCRLDP.Contains("(")) -and ($CertCRLDP.Contains(")")) ) {
-                    #    $CertCRLDP = ($CertCRLDP.Substring(($CertCRLDP.IndexOf("(") + 1))).TrimEnd(")")
-                    #}
+                    if ( ($CertCRLDP.Contains("(")) -and ($CertCRLDP.Contains(")")) ) {
+                        $CertCRLDP = ($CertCRLDP.Substring(($CertCRLDP.IndexOf("(") + 1))).TrimEnd(")")
+                    }
                     Write-FormattedHost -Message "CA KDC cert on Domain Controller $($DCC.PSComputerName) HTTP CRL is:" -ResultState Pass -ResultMessage $CertCRLDP
                     $CACRLValid = Get-WHFBCACRLValid -crl (Invoke-WebRequest -Uri $CertCRLDP -UseBasicParsing).content
                     if ($CACRLValid.CAName -ne $ca.CAName) {


### PR DESCRIPTION
This pull request is to propose the enabling of the parser for CDP URI's.
After looking into why CDP was consistently failing I have found that with this commented out a CDP of 
http://www.testme/cdp/testcrl.crl (http://www.testme/cdp/testcrl.crl) is performed as a web request of the whole block.

2023-03-23 22:05:56 172.18.15.60 GET /cdp/My+Root+Certificate+Authority.crl+(http:/root.contoso.com/cdp/My+Root+Certificate+Authority.crl) - 80 - 172.18.0.9 Mozilla/5.0+(Windows+NT;+Windows+NT+10.0;+en-AU)+WindowsPowerShell/5.1.19041.2673 - 404 0 2 37

the CDP extension looks like this 
URL=http://root.contoso.com/cdp/My Root Certificate Authority.crl (http://root.contoso.com/cdp/My%20Root%20Certificate%20Authority.crl)

If by enabling the parser it breaks other stuff, perhaps a test for () before choosing to enable or not. Given that this format is used in ADCS It probably should be implemented first. 

closes #13 #12 