### PR TITLE
Update Get-WHFBAACCurrentVersion.ps1

### DIFF
--- a/WHFBCHECKS/private/Get-WHFBAACCurrentVersion.ps1
+++ b/WHFBCHECKS/private/Get-WHFBAACCurrentVersion.ps1
@@ -5,11 +5,11 @@ This will query the Docs page for the latest version of AAD Connect
 
 .DESCRIPTION
 
-This function will query this address: https://raw.githubusercontent.com/MicrosoftDocs/azure-docs/main/articles/active-directory/hybrid/connect/reference-connect-version-history.md and perform a regex to return the list of all supported versions of AAD Connect.
+This function will query this address: https://raw.githubusercontent.com/MicrosoftDocs/entra-docs/main/docs/identity/hybrid/connect/reference-connect-version-history.md and perform a regex to return the list of all supported versions of AAD Connect.
 #>
 function Get-WHFBAACCurrentVersion {
     $regex = [regex] "## ((?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"
-    $AADConnectRelWR = Invoke-RestMethod -Method Get -Uri "https://raw.githubusercontent.com/MicrosoftDocs/azure-docs/main/articles/active-directory/hybrid/connect/reference-connect-version-history.md" -UseBasicParsing
+    $AADConnectRelWR = Invoke-RestMethod -Method Get -Uri "https://raw.githubusercontent.com/MicrosoftDocs/entra-docs/main/docs/identity/hybrid/connect/reference-connect-version-history.md" -UseBasicParsing
     [version[]]$AADConnectReleases = $regex.matches(($AADConnectRelWR.split("\n\r"))).value | ForEach-Object {$_.trim("## ")}
     [version[]]$AADConnectReleases = $AADConnectReleases | Sort-Object -Descending -Unique
     return [string[]]$AADConnectReleases


### PR DESCRIPTION
Updated Microsoft Docs URL to Fix the Entra Connect Version Check

This is the new URL for the document
https://raw.githubusercontent.com/MicrosoftDocs/entra-docs/main/docs/identity/hybrid/connect/reference-connect-version-history.md